### PR TITLE
fix: add missing ROLL_OVER and PULL_TO_SIT types to OpenAPI schema

### DIFF
--- a/apps/web/openapi.yaml
+++ b/apps/web/openapi.yaml
@@ -645,6 +645,8 @@ components:
         - BOTTLE
         - HEAD_LIFT
         - PASSIVE_EXERCISE
+        - ROLL_OVER
+        - PULL_TO_SIT
         - GAS_EXERCISE
         - BATH
         - OUTDOOR
@@ -816,6 +818,10 @@ components:
         spitUpType:
           $ref: '#/components/schemas/SpitUpType'
           nullable: true
+        count:
+          type: integer
+          nullable: true
+          description: 次数（用于翻身、拉坐等计数类活动）
         notes:
           type: string
           nullable: true
@@ -856,6 +862,9 @@ components:
           $ref: '#/components/schemas/SupplementType'
         spitUpType:
           $ref: '#/components/schemas/SpitUpType'
+        count:
+          type: integer
+          description: 次数（用于翻身、拉坐等计数类活动）
         notes:
           type: string
         force:
@@ -895,6 +904,9 @@ components:
           $ref: '#/components/schemas/SupplementType'
         spitUpType:
           $ref: '#/components/schemas/SpitUpType'
+        count:
+          type: integer
+          description: 次数（用于翻身、拉坐等计数类活动）
         notes:
           type: string
 

--- a/apps/web/src/lib/api/openapi-types.d.ts
+++ b/apps/web/src/lib/api/openapi-types.d.ts
@@ -201,7 +201,7 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /** @enum {string} */
-        ActivityType: "SLEEP" | "DIAPER" | "BREASTFEED" | "BOTTLE" | "HEAD_LIFT" | "PASSIVE_EXERCISE" | "GAS_EXERCISE" | "BATH" | "OUTDOOR" | "EARLY_EDUCATION" | "SUPPLEMENT" | "SPIT_UP";
+        ActivityType: "SLEEP" | "DIAPER" | "BREASTFEED" | "BOTTLE" | "HEAD_LIFT" | "PASSIVE_EXERCISE" | "ROLL_OVER" | "PULL_TO_SIT" | "GAS_EXERCISE" | "BATH" | "OUTDOOR" | "EARLY_EDUCATION" | "SUPPLEMENT" | "SPIT_UP";
         /** @enum {string} */
         PoopColor: "YELLOW" | "GREEN" | "BROWN" | "BLACK" | "WHITE" | "RED";
         /** @enum {string} */
@@ -272,6 +272,8 @@ export interface components {
             breastFirmness?: components["schemas"]["BreastFirmness"];
             supplementType?: components["schemas"]["SupplementType"];
             spitUpType?: components["schemas"]["SpitUpType"];
+            /** @description 次数（用于翻身、拉坐等计数类活动） */
+            count?: number | null;
             notes?: string | null;
         };
         CreateActivityInput: {
@@ -296,6 +298,8 @@ export interface components {
             breastFirmness?: components["schemas"]["BreastFirmness"];
             supplementType?: components["schemas"]["SupplementType"];
             spitUpType?: components["schemas"]["SpitUpType"];
+            /** @description 次数（用于翻身、拉坐等计数类活动） */
+            count?: number;
             notes?: string;
             /** @description Force create even if there's an overlap warning (not for duplicates) */
             force?: boolean;
@@ -322,6 +326,8 @@ export interface components {
             breastFirmness?: components["schemas"]["BreastFirmness"];
             supplementType?: components["schemas"]["SupplementType"];
             spitUpType?: components["schemas"]["SpitUpType"];
+            /** @description 次数（用于翻身、拉坐等计数类活动） */
+            count?: number;
             notes?: string;
         };
         BabyProfile: {


### PR DESCRIPTION
- Added ROLL_OVER and PULL_TO_SIT to ActivityType enum in openapi.yaml
- Added count field to Activity, CreateActivityInput, and UpdateActivityInput schemas
- Regenerated openapi-types.d.ts to fix TypeScript build errors