### PR TITLE
ci(bubu-log): auto cleanup neon preview branches

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,18 @@
+name: Delete Neon Branch on PR Close
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_branch:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon branch
+        uses: neondatabase/delete-branch-action@v5.1.0
+        with:
+          project_id: ${{ vars.BUBU_LOG_NEON_PROJECT_ID }}
+          api_key: ${{ secrets.BUBU_LOG_NEON_API_KEY }}
+          pr-ref: ${{ github.event.number }}


### PR DESCRIPTION
## Summary\n- add cleanup workflow to delete Neon preview branch when PR is closed\n- scope Neon credentials for bubu-log monorepo app via prefixed vars/secrets\n\n## Config required\n- vars.BUBU_LOG_NEON_PROJECT_ID\n- secrets.BUBU_LOG_NEON_API_KEY\n