### PR TITLE
ci: fix Neon cleanup workflow input

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           project_id: ${{ vars.BUBU_LOG_NEON_PROJECT_ID }}
           api_key: ${{ secrets.BUBU_LOG_NEON_API_KEY }}
-          pr-ref: ${{ github.event.number }}
+          branch: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary
- replace unsupported `pr-ref` input in `neondatabase/delete-branch-action@v3`
- pass `branch: ${{ github.event.pull_request.head.ref }}` so cleanup deletes the correct Neon preview branch

## Root cause
`cleanup-preview.yml` used `pr-ref`, which is not a valid input for `delete-branch-action@v3`, causing the action to call `neonctl branches delete` with an empty argument and fail.

## Validation
- inspected failing run/job logs: https://github.com/Stupidism/sunmer-home/actions/runs/22307006157/job/64528719670