### PR TITLE
ci: fix Neon cleanup branch naming

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           project_id: ${{ vars.BUBU_LOG_NEON_PROJECT_ID }}
           api_key: ${{ secrets.BUBU_LOG_NEON_API_KEY }}
-          branch: ${{ github.event.pull_request.head.ref }}
+          branch: preview/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary
- update cleanup workflow to delete the Neon preview branch name that actually exists
- use `preview/${{ github.event.pull_request.head.ref }}` for `delete-branch-action@v3`

## Root cause
The previous fix switched to `branch`, but Neon branches are created with a `preview/` prefix. Deleting `${{ github.event.pull_request.head.ref }}` failed with:

`ERROR: Branch <name> not found. Available branches: preview/<name>, ...`

## Validation
- failing close-PR run: https://github.com/Stupidism/sunmer-home/actions/runs/22310083991/job/64539468687
