### PR TITLE
feat(bubu-log): rewrite batch parse with unified AI processing (SUN-10)

### DIFF
--- a/apps/bubu-log/openapi.yaml
+++ b/apps/bubu-log/openapi.yaml
@@ -358,6 +358,7 @@ paths:
                     properties:
                       text:
                         type: string
+                        minLength: 1
                         description: The message text
                       localTime:
                         type: string
@@ -365,6 +366,7 @@ paths:
                     required:
                       - text
                       - localTime
+                  minItems: 1
                   maxItems: 50
               required:
                 - entries

--- a/apps/bubu-log/openapi.yaml
+++ b/apps/bubu-log/openapi.yaml
@@ -336,6 +336,141 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /batch-parse:
+    post:
+      operationId: batchParse
+      summary: Parse multiple chat messages with unified AI processing
+      description: |
+        Accepts an array of chat message entries (text + timestamp) and sends them all to AI
+        for holistic analysis. The AI identifies activities, pairs start/end events, handles
+        cancellations, and returns structured data with action (create/update/skip) for each.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                entries:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      text:
+                        type: string
+                        description: The message text
+                      localTime:
+                        type: string
+                        description: Message timestamp (e.g. "2026-03-27 08:49")
+                    required:
+                      - text
+                      - localTime
+                  maxItems: 50
+              required:
+                - entries
+      responses:
+        '200':
+          description: Parsed activity items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BatchParsedItem'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+    put:
+      operationId: batchConfirm
+      summary: Batch create/update confirmed activities
+      description: |
+        After user reviews the parsed items, submit confirmed items for creation or update.
+        Each item must have an explicit action field (create/update/skip).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/BatchConfirmItem'
+              required:
+                - items
+      responses:
+        '200':
+          description: Batch operation results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        originalTexts:
+                          type: array
+                          items:
+                            type: string
+                  updated:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        originalTexts:
+                          type: array
+                          items:
+                            type: string
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        originalTexts:
+                          type: array
+                          items:
+                            type: string
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        originalTexts:
+                          type: array
+                          items:
+                            type: string
+                        error:
+                          type: string
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /voice-input:
     post:
       operationId: parseVoiceInput
@@ -960,6 +1095,138 @@ components:
         birthDate:
           type: string
           format: date-time
+
+    BatchParsedItem:
+      type: object
+      required:
+        - action
+        - type
+        - startTime
+        - originalTexts
+      properties:
+        action:
+          type: string
+          enum:
+            - create
+            - update
+            - skip
+        type:
+          $ref: '#/components/schemas/ActivityType'
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+          nullable: true
+        milkAmount:
+          type: integer
+          nullable: true
+        milkSource:
+          $ref: '#/components/schemas/MilkSource'
+          nullable: true
+        duration:
+          type: integer
+          nullable: true
+          description: Duration in minutes
+        hasPoop:
+          type: boolean
+          nullable: true
+        hasPee:
+          type: boolean
+          nullable: true
+        poopColor:
+          $ref: '#/components/schemas/PoopColor'
+          nullable: true
+        peeAmount:
+          $ref: '#/components/schemas/PeeAmount'
+          nullable: true
+        spitUpType:
+          $ref: '#/components/schemas/SpitUpType'
+          nullable: true
+        supplementType:
+          $ref: '#/components/schemas/SupplementType'
+          nullable: true
+        count:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        skipReason:
+          type: string
+          nullable: true
+          description: Reason for skip (only when action=skip)
+        originalTexts:
+          type: array
+          items:
+            type: string
+          description: Original chat message texts that map to this item
+        existingActivityId:
+          type: string
+          nullable: true
+          description: ID of existing activity to update (only for action=update)
+
+    BatchConfirmItem:
+      type: object
+      required:
+        - action
+        - type
+        - startTime
+      properties:
+        action:
+          type: string
+          enum:
+            - create
+            - update
+            - skip
+        type:
+          $ref: '#/components/schemas/ActivityType'
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+          nullable: true
+        existingActivityId:
+          type: string
+          nullable: true
+          description: Required for action=update
+        milkAmount:
+          type: integer
+          nullable: true
+        milkSource:
+          $ref: '#/components/schemas/MilkSource'
+          nullable: true
+        hasPoop:
+          type: boolean
+          nullable: true
+        hasPee:
+          type: boolean
+          nullable: true
+        poopColor:
+          $ref: '#/components/schemas/PoopColor'
+          nullable: true
+        peeAmount:
+          $ref: '#/components/schemas/PeeAmount'
+          nullable: true
+        spitUpType:
+          $ref: '#/components/schemas/SpitUpType'
+          nullable: true
+        supplementType:
+          $ref: '#/components/schemas/SupplementType'
+          nullable: true
+        count:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        originalTexts:
+          type: array
+          items:
+            type: string
 
     Error:
       type: object

--- a/apps/bubu-log/src/app/(frontend)/(app)/b/[babyId]/batch-import/page.tsx
+++ b/apps/bubu-log/src/app/(frontend)/(app)/b/[babyId]/batch-import/page.tsx
@@ -512,6 +512,8 @@ export default function BatchImportPage() {
                 {submitResult.created > 0 && `新建 ${submitResult.created} 条`}
                 {submitResult.created > 0 && submitResult.updated > 0 && '，'}
                 {submitResult.updated > 0 && `更新 ${submitResult.updated} 条`}
+                {(submitResult.created > 0 || submitResult.updated > 0) && submitResult.skipped > 0 && '，'}
+                {submitResult.skipped > 0 && `跳过 ${submitResult.skipped} 条`}
                 {submitResult.errors > 0 && `，${submitResult.errors} 条失败`}
               </p>
             </div>

--- a/apps/bubu-log/src/app/(frontend)/(app)/b/[babyId]/batch-import/page.tsx
+++ b/apps/bubu-log/src/app/(frontend)/(app)/b/[babyId]/batch-import/page.tsx
@@ -8,11 +8,12 @@ import {
   FileUp,
   Loader2,
   Check,
-  X,
   AlertCircle,
   CheckCircle2,
   Square,
   CheckSquare,
+  ArrowUpCircle,
+  SkipForward,
 } from 'lucide-react'
 import { ActivityType, ActivityTypeLabels, MilkSourceLabels } from '@/types/activity'
 import { dayjs } from '@/lib/dayjs'
@@ -21,33 +22,32 @@ import { BackHomeButton } from '@/components/BackHomeButton'
 import { withCurrentBabyIdOnApiPath } from '@/lib/baby-scope'
 
 interface ParsedItem {
+  action: 'create' | 'update' | 'skip'
   type: ActivityType
-  startTimeISO: string
-  endTimeISO: string | null
+  startTime: string
+  endTime: string | null
   milkAmount: number | null
   milkSource: string | null
+  duration: number | null
   hasPoop: boolean | null
   hasPee: boolean | null
   poopColor: string | null
   peeAmount: string | null
   spitUpType: string | null
+  supplementType: string | null
   count: number | null
   notes: string | null
-  confidence: number
-}
-
-interface BatchResult {
-  originalText: string
-  parsed?: ParsedItem
-  error?: string
+  skipReason: string | null
+  originalTexts: string[]
+  existingActivityId?: string | null
 }
 
 type Step = 'input' | 'review' | 'done'
 
-// 日期时间行的正则：2026/3/27 08:49 或 2026-03-27 08:49
+// Date-time line regex: 2026/3/27 08:49 or 2026-03-27 08:49
 const DATETIME_RE = /^\d{4}[/-]\d{1,2}[/-]\d{1,2}\s+\d{1,2}:\d{2}/
 
-// 标题/头部行（如【宝宝每日数据记录】）
+// Header lines (e.g. 【宝宝每日数据记录】)
 const HEADER_RE = /^[【\[]/
 
 interface BatchEntry {
@@ -56,9 +56,9 @@ interface BatchEntry {
 }
 
 /**
- * 解析粘贴的文本，支持两种格式：
- * 1. 带时间戳的两行格式：时间戳行 + 描述行
- * 2. 纯文本格式：每行一条记录
+ * Parse pasted text, supporting two formats:
+ * 1. Timestamped two-line format: timestamp line + description line
+ * 2. Plain text: one record per line
  */
 function parseInputText(raw: string): BatchEntry[] {
   const lines = raw.split('\n').map((l) => l.trim())
@@ -70,11 +70,9 @@ function parseInputText(raw: string): BatchEntry[] {
 
   for (const line of lines) {
     if (!line) continue
-    // 跳过标题行
     if (HEADER_RE.test(line)) continue
 
     if (DATETIME_RE.test(line)) {
-      // 这是时间戳行，规范化格式：2026/3/27 08:49 -> 2026-03-27 08:49
       const normalized = line
         .replace(/\//g, '-')
         .replace(/(\d{4})-(\d{1,2})-(\d{1,2})/, (_, y, m, d) =>
@@ -83,7 +81,6 @@ function parseInputText(raw: string): BatchEntry[] {
       continue
     }
 
-    // 这是描述行
     entries.push({
       text: line,
       localTime: pendingTime || fallbackTime,
@@ -97,15 +94,17 @@ function parseInputText(raw: string): BatchEntry[] {
 function formatParsedSummary(p: ParsedItem): string {
   const parts: string[] = [ActivityTypeLabels[p.type] || p.type]
 
-  const start = dayjs(p.startTimeISO)
+  const start = dayjs(p.startTime)
   parts.push(start.format('HH:mm'))
 
-  if (p.endTimeISO) {
-    const end = dayjs(p.endTimeISO)
+  if (p.endTime) {
+    const end = dayjs(p.endTime)
     const durationMin = end.diff(start, 'minute')
     if (durationMin > 0) {
       parts.push(`${durationMin}分钟`)
     }
+  } else if (p.duration) {
+    parts.push(`${p.duration}分钟`)
   }
 
   if (p.milkAmount) {
@@ -123,6 +122,37 @@ function formatParsedSummary(p: ParsedItem): string {
   return parts.join(' / ')
 }
 
+const ACTION_LABELS: Record<string, string> = {
+  create: '新建',
+  update: '更新',
+  skip: '跳过',
+}
+
+function ActionBadge({ action }: { action: string }) {
+  if (action === 'create') {
+    return (
+      <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 text-xs font-medium">
+        <Check size={12} />
+        {ACTION_LABELS[action]}
+      </span>
+    )
+  }
+  if (action === 'update') {
+    return (
+      <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-xs font-medium">
+        <ArrowUpCircle size={12} />
+        {ACTION_LABELS[action]}
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs font-medium">
+      <SkipForward size={12} />
+      {ACTION_LABELS[action]}
+    </span>
+  )
+}
+
 export default function BatchImportPage() {
   const params = useParams()
   const babyId = params.babyId as string
@@ -132,9 +162,14 @@ export default function BatchImportPage() {
   const [inputText, setInputText] = useState('')
   const [isParsing, setIsParsing] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [results, setResults] = useState<BatchResult[]>([])
+  const [items, setItems] = useState<ParsedItem[]>([])
   const [checked, setChecked] = useState<boolean[]>([])
-  const [submitResult, setSubmitResult] = useState<{ created: number; errors: number } | null>(null)
+  const [submitResult, setSubmitResult] = useState<{
+    created: number
+    updated: number
+    skipped: number
+    errors: number
+  } | null>(null)
 
   const handleParse = useCallback(async () => {
     const entries = parseInputText(inputText)
@@ -159,10 +194,10 @@ export default function BatchImportPage() {
         return
       }
 
-      const batchResults: BatchResult[] = data.results
-      setResults(batchResults)
-      // Default: check all successfully parsed items
-      setChecked(batchResults.map((r) => !!r.parsed))
+      const parsedItems: ParsedItem[] = data.items
+      setItems(parsedItems)
+      // Default: check all non-skip items
+      setChecked(parsedItems.map((item) => item.action !== 'skip'))
       setStep('review')
     } catch {
       toast.error('网络错误，请重试')
@@ -181,35 +216,40 @@ export default function BatchImportPage() {
 
   const toggleAll = useCallback(() => {
     setChecked((prev) => {
-      const allChecked = prev.every((c, i) => !results[i]?.parsed || c)
-      return prev.map((c, i) => (results[i]?.parsed ? !allChecked : c))
+      const allNonSkipChecked = items.every((item, i) => item.action === 'skip' || prev[i])
+      return items.map((item) =>
+        item.action === 'skip' ? false : !allNonSkipChecked,
+      )
     })
-  }, [results])
+  }, [items])
 
-  const checkedCount = checked.filter((c, i) => c && results[i]?.parsed).length
-  const parsedCount = results.filter((r) => r.parsed).length
+  const actionableItems = items.filter((item) => item.action !== 'skip')
+  const checkedCount = checked.filter((c, i) => c && items[i]?.action !== 'skip').length
 
   const handleSubmit = useCallback(async () => {
-    const items = results
+    const selectedItems = items
       .filter((_, i) => checked[i])
-      .filter((r) => r.parsed)
-      .map((r) => ({
-        type: r.parsed!.type,
-        startTime: r.parsed!.startTimeISO,
-        endTime: r.parsed!.endTimeISO,
-        milkAmount: r.parsed!.milkAmount,
-        milkSource: r.parsed!.milkSource,
-        hasPoop: r.parsed!.hasPoop,
-        hasPee: r.parsed!.hasPee,
-        poopColor: r.parsed!.poopColor,
-        peeAmount: r.parsed!.peeAmount,
-        spitUpType: r.parsed!.spitUpType,
-        count: r.parsed!.count,
-        notes: r.parsed!.notes,
-        originalText: r.originalText,
+      .filter((item) => item.action !== 'skip')
+      .map((item) => ({
+        action: item.action,
+        type: item.type,
+        startTime: item.startTime,
+        endTime: item.endTime,
+        existingActivityId: item.existingActivityId || null,
+        milkAmount: item.milkAmount,
+        milkSource: item.milkSource,
+        hasPoop: item.hasPoop,
+        hasPee: item.hasPee,
+        poopColor: item.poopColor,
+        peeAmount: item.peeAmount,
+        spitUpType: item.spitUpType,
+        supplementType: item.supplementType,
+        count: item.count,
+        notes: item.notes,
+        originalTexts: item.originalTexts,
       }))
 
-    if (items.length === 0) {
+    if (selectedItems.length === 0) {
       toast.error('请至少选择一条记录')
       return
     }
@@ -219,7 +259,7 @@ export default function BatchImportPage() {
       const response = await fetch(withCurrentBabyIdOnApiPath('/api/app/batch-parse'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ items }),
+        body: JSON.stringify({ items: selectedItems }),
       })
 
       const data = await response.json()
@@ -230,30 +270,38 @@ export default function BatchImportPage() {
       }
 
       const createdCount = data.created?.length ?? 0
+      const updatedCount = data.updated?.length ?? 0
+      const skippedCount = data.skipped?.length ?? 0
       const errorCount = data.errors?.length ?? 0
-      setSubmitResult({ created: createdCount, errors: errorCount })
+      setSubmitResult({
+        created: createdCount,
+        updated: updatedCount,
+        skipped: skippedCount,
+        errors: errorCount,
+      })
       setStep('done')
 
       queryClient.invalidateQueries({ queryKey: ['get', '/activities'] })
       queryClient.invalidateQueries({ queryKey: ['get', '/activities/latest'] })
 
-      if (createdCount > 0) {
-        toast.success(`成功导入 ${createdCount} 条记录`)
+      const totalSuccess = createdCount + updatedCount
+      if (totalSuccess > 0) {
+        toast.success(`成功处理 ${totalSuccess} 条记录`)
       }
       if (errorCount > 0) {
-        toast.error(`${errorCount} 条记录创建失败`)
+        toast.error(`${errorCount} 条记录处理失败`)
       }
     } catch {
       toast.error('网络错误，请重试')
     } finally {
       setIsSubmitting(false)
     }
-  }, [results, checked, queryClient])
+  }, [items, checked, queryClient])
 
   const handleReset = useCallback(() => {
     setStep('input')
     setInputText('')
-    setResults([])
+    setItems([])
     setChecked([])
     setSubmitResult(null)
   }, [])
@@ -337,25 +385,27 @@ export default function BatchImportPage() {
             <div className="bg-white dark:bg-gray-900 rounded-2xl p-4 shadow-sm">
               <div className="flex items-center justify-between mb-3">
                 <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  解析结果 ({parsedCount}/{results.length} 条成功)
+                  解析结果 ({actionableItems.length} 条可导入，{items.length - actionableItems.length} 条跳过)
                 </p>
-                <button
-                  data-testid="batch-toggle-all"
-                  onClick={toggleAll}
-                  className="text-xs text-violet-600 dark:text-violet-400 font-medium"
-                >
-                  {checkedCount === parsedCount ? '取消全选' : '全选'}
-                </button>
+                {actionableItems.length > 0 && (
+                  <button
+                    data-testid="batch-toggle-all"
+                    onClick={toggleAll}
+                    className="text-xs text-violet-600 dark:text-violet-400 font-medium"
+                  >
+                    {checkedCount === actionableItems.length ? '取消全选' : '全选'}
+                  </button>
+                )}
               </div>
 
               <div className="space-y-2">
-                {results.map((item, index) => (
+                {items.map((item, index) => (
                   <div
                     key={index}
                     data-testid={`batch-result-item-${index}`}
                     className={`rounded-xl border p-3 transition-colors ${
-                      item.error
-                        ? 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20'
+                      item.action === 'skip'
+                        ? 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 opacity-60'
                         : checked[index]
                           ? 'border-violet-200 dark:border-violet-800 bg-violet-50 dark:bg-violet-900/20'
                           : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800'
@@ -363,7 +413,7 @@ export default function BatchImportPage() {
                   >
                     <div className="flex items-start gap-3">
                       {/* Checkbox */}
-                      {item.parsed ? (
+                      {item.action !== 'skip' ? (
                         <button
                           data-testid={`batch-check-${index}`}
                           onClick={() => toggleItem(index)}
@@ -377,36 +427,40 @@ export default function BatchImportPage() {
                         </button>
                       ) : (
                         <div className="mt-0.5 flex-shrink-0">
-                          <AlertCircle size={20} className="text-red-500" />
+                          <AlertCircle size={20} className="text-gray-400" />
                         </div>
                       )}
 
                       <div className="flex-1 min-w-0">
-                        {/* Original text */}
+                        {/* Original texts */}
                         <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">
-                          &quot;{item.originalText}&quot;
+                          {item.originalTexts.map((t, i) => (
+                            <span key={i}>
+                              {i > 0 && ' + '}
+                              &quot;{t}&quot;
+                            </span>
+                          ))}
                         </p>
 
                         {/* Parsed result */}
-                        {item.parsed ? (
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs font-medium">
-                              {ActivityTypeLabels[item.parsed.type] || item.parsed.type}
-                            </span>
-                            <span className="text-sm text-gray-700 dark:text-gray-300">
-                              {formatParsedSummary(item.parsed)}
-                            </span>
-                            {item.parsed.confidence < 0.75 && (
-                              <span className="text-xs text-amber-600 dark:text-amber-400">
-                                (低置信度)
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <ActionBadge action={item.action} />
+                          {item.action !== 'skip' && (
+                            <>
+                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs font-medium">
+                                {ActivityTypeLabels[item.type] || item.type}
                               </span>
-                            )}
-                          </div>
-                        ) : (
-                          <p className="text-sm text-red-600 dark:text-red-400">
-                            {item.error}
-                          </p>
-                        )}
+                              <span className="text-sm text-gray-700 dark:text-gray-300">
+                                {formatParsedSummary(item)}
+                              </span>
+                            </>
+                          )}
+                          {item.action === 'skip' && item.skipReason && (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              {item.skipReason}
+                            </span>
+                          )}
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -455,7 +509,9 @@ export default function BatchImportPage() {
                 导入完成
               </h2>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                成功导入 {submitResult.created} 条记录
+                {submitResult.created > 0 && `新建 ${submitResult.created} 条`}
+                {submitResult.created > 0 && submitResult.updated > 0 && '，'}
+                {submitResult.updated > 0 && `更新 ${submitResult.updated} 条`}
                 {submitResult.errors > 0 && `，${submitResult.errors} 条失败`}
               </p>
             </div>

--- a/apps/bubu-log/src/app/api/app/batch-parse/route.ts
+++ b/apps/bubu-log/src/app/api/app/batch-parse/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { authFailureResponse, getRequestedBabyId, requireAuth } from '@/lib/auth/get-current-baby'
 import { batchParseWithAI, type BatchEntry, type BatchParsedItem } from '@/lib/batch-parse/process'
-import { ActivityType } from '@/types/activity'
+import { ActivityType, type MilkSource, type PoopColor, type PeeAmount, type SpitUpType, type SupplementType } from '@/types/activity'
 import { getPayloadClient } from '@/lib/payload/client'
 import { createAuditLog } from '@/lib/payload/audit'
 import type { ActivityDoc } from '@/lib/payload/models'
@@ -73,18 +73,18 @@ export async function POST(request: NextRequest) {
 // Confirmed item sent by frontend
 interface ConfirmedItem {
   action: 'create' | 'update' | 'skip'
-  type: string
+  type: ActivityType
   startTime: string
   endTime?: string | null
   existingActivityId?: string | null
   milkAmount?: number | null
-  milkSource?: string | null
+  milkSource?: MilkSource | null
   hasPoop?: boolean | null
   hasPee?: boolean | null
-  poopColor?: string | null
-  peeAmount?: string | null
-  spitUpType?: string | null
-  supplementType?: string | null
+  poopColor?: PoopColor | null
+  peeAmount?: PeeAmount | null
+  spitUpType?: SpitUpType | null
+  supplementType?: SupplementType | null
   count?: number | null
   notes?: string | null
   originalTexts?: string[]

--- a/apps/bubu-log/src/app/api/app/batch-parse/route.ts
+++ b/apps/bubu-log/src/app/api/app/batch-parse/route.ts
@@ -1,30 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { authFailureResponse, getRequestedBabyId, requireAuth } from '@/lib/auth/get-current-baby'
-import { callDeepseek, type ParsedActivity } from '@/lib/voice-input/process'
+import { batchParseWithAI, type BatchEntry, type BatchParsedItem } from '@/lib/batch-parse/process'
 import { ActivityType } from '@/types/activity'
 import { getPayloadClient } from '@/lib/payload/client'
 import { createAuditLog } from '@/lib/payload/audit'
+import type { ActivityDoc } from '@/lib/payload/models'
 
-const POINT_EVENT_TYPES = ['DIAPER', 'SUPPLEMENT', 'SPIT_UP', 'ROLL_OVER', 'PULL_TO_SIT']
-
-interface BatchParseItem {
-  originalText: string
-  parsed?: ParsedActivity & { startTimeISO: string; endTimeISO: string | null }
-  error?: string
-}
-
-// Each entry has its own text and timestamp
-interface BatchEntry {
-  text: string
-  localTime: string
-}
-
-// POST: Parse multiple lines of voice input text
+// POST: Parse multiple chat messages with unified AI processing
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json().catch(() => ({} as Record<string, unknown>))
-    const entries = Array.isArray(body.entries) ? body.entries as BatchEntry[] : []
-    const fallbackTime = typeof body.localTime === 'string' ? body.localTime : new Date().toISOString()
+    const entries = Array.isArray(body.entries) ? (body.entries as BatchEntry[]) : []
 
     if (entries.length === 0) {
       return NextResponse.json({ error: '请提供至少一条记录' }, { status: 400 })
@@ -34,54 +20,44 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: '单次最多解析50条记录' }, { status: 400 })
     }
 
-    await requireAuth({ babyId: getRequestedBabyId(request) })
+    const { baby } = await requireAuth({ babyId: getRequestedBabyId(request) })
+    const payload = await getPayloadClient()
 
-    // Parse all entries in parallel
-    const results: BatchParseItem[] = await Promise.all(
-      entries.map(async (entry): Promise<BatchParseItem> => {
-        const text = (entry.text || '').trim()
-        if (!text) {
-          return { originalText: '', error: '空行' }
+    // Send all entries to AI at once for holistic parsing
+    const items = await batchParseWithAI(entries)
+
+    // For update actions on SLEEP, look up unclosed sleep records
+    for (const item of items) {
+      if (item.action === 'update' && item.type === ('SLEEP' as ActivityType)) {
+        const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString()
+
+        const unclosedSleep = await payload.find({
+          collection: 'activities',
+          where: {
+            and: [
+              { babyId: { equals: baby.id } },
+              { type: { equals: 'SLEEP' } },
+              { endTime: { exists: false } },
+              { startTime: { greater_than: twelveHoursAgo } },
+            ],
+          },
+          sort: '-startTime',
+          limit: 1,
+          pagination: false,
+          depth: 0,
+          overrideAccess: true,
+        })
+
+        if (unclosedSleep.docs.length > 0) {
+          const existing = unclosedSleep.docs[0] as ActivityDoc
+          // Attach the existing activity ID so frontend/PUT handler can use it
+          ;(item as BatchParsedItem & { existingActivityId?: string }).existingActivityId =
+            existing.id
         }
+      }
+    }
 
-        const localTime = entry.localTime || fallbackTime
-
-        try {
-          const result = await callDeepseek(text, localTime)
-
-          if ('error' in result) {
-            return { originalText: text, error: result.error }
-          }
-
-          if (!Object.values(ActivityType).includes(result.type)) {
-            return { originalText: text, error: `无效的活动类型: ${result.type}` }
-          }
-
-          const startTime = result.startTime
-            ? new Date(result.startTime)
-            : new Date()
-
-          const isPointEvent = POINT_EVENT_TYPES.includes(result.type)
-          const endTime = isPointEvent
-            ? startTime
-            : (result.endTime ? new Date(result.endTime) : null)
-
-          return {
-            originalText: text,
-            parsed: {
-              ...result,
-              startTimeISO: startTime.toISOString(),
-              endTimeISO: endTime ? endTime.toISOString() : null,
-            },
-          }
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : '解析失败'
-          return { originalText: text, error: msg }
-        }
-      })
-    )
-
-    return NextResponse.json({ results })
+    return NextResponse.json({ items })
   } catch (error) {
     const authError = authFailureResponse(error)
     if (authError) return authError
@@ -94,19 +70,128 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// PUT: Batch create confirmed activities
+// Confirmed item sent by frontend
+interface ConfirmedItem {
+  action: 'create' | 'update' | 'skip'
+  type: string
+  startTime: string
+  endTime?: string | null
+  existingActivityId?: string | null
+  milkAmount?: number | null
+  milkSource?: string | null
+  hasPoop?: boolean | null
+  hasPee?: boolean | null
+  poopColor?: string | null
+  peeAmount?: string | null
+  spitUpType?: string | null
+  supplementType?: string | null
+  count?: number | null
+  notes?: string | null
+  originalTexts?: string[]
+}
+
+// PUT: Batch create/update confirmed activities
 export async function PUT(request: NextRequest) {
   try {
     const body = await request.json().catch(() => ({} as Record<string, unknown>))
-    const items = Array.isArray(body.items) ? body.items : []
+    const items = Array.isArray(body.items) ? (body.items as ConfirmedItem[]) : []
+
+    if (items.length === 0) {
+      return NextResponse.json({ error: '请提供至少一条记录' }, { status: 400 })
+    }
+
+    // Validate: every item must have an explicit action
+    for (const item of items) {
+      if (!item.action || !['create', 'update', 'skip'].includes(item.action)) {
+        return NextResponse.json(
+          { error: '每条记录必须包含有效的 action 字段（create/update/skip）' },
+          { status: 400 },
+        )
+      }
+    }
 
     const { baby, user } = await requireAuth({ babyId: getRequestedBabyId(request) })
     const payload = await getPayloadClient()
 
-    const created: Array<{ id: string; type: string; originalText: string }> = []
-    const errors: Array<{ originalText: string; error: string }> = []
+    const created: Array<{ id: string; type: string; originalTexts: string[] }> = []
+    const updated: Array<{ id: string; type: string; originalTexts: string[] }> = []
+    const skipped: Array<{ originalTexts: string[] }> = []
+    const errors: Array<{ originalTexts: string[]; error: string }> = []
 
     for (const item of items) {
+      const originalTexts = item.originalTexts || []
+
+      if (item.action === 'skip') {
+        skipped.push({ originalTexts })
+        continue
+      }
+
+      if (item.action === 'update') {
+        // Update an existing activity (e.g., set endTime on unclosed SLEEP)
+        const activityId = item.existingActivityId
+        if (!activityId) {
+          errors.push({ originalTexts, error: '缺少 existingActivityId' })
+          continue
+        }
+
+        try {
+          // Verify the activity belongs to this baby
+          const existing = await payload.findByID({
+            collection: 'activities',
+            id: activityId,
+            depth: 0,
+            overrideAccess: true,
+          })
+
+          if (!existing || (existing as ActivityDoc).babyId !== baby.id) {
+            errors.push({ originalTexts, error: '活动不存在或不属于当前宝宝' })
+            continue
+          }
+
+          const updateData: Record<string, unknown> = {}
+          if (item.endTime) updateData.endTime = item.endTime
+
+          const updatedActivity = await payload.update({
+            collection: 'activities',
+            id: activityId,
+            data: updateData,
+            depth: 0,
+            overrideAccess: true,
+          })
+
+          updated.push({
+            id: String(updatedActivity.id),
+            type: item.type,
+            originalTexts,
+          })
+
+          try {
+            await createAuditLog(payload, {
+              action: 'UPDATE',
+              resourceId: activityId,
+              inputMethod: 'VOICE',
+              inputText: originalTexts.join(' | '),
+              description: `批量导入: 更新${item.type} endTime`,
+              success: true,
+              beforeData: existing,
+              afterData: updatedActivity,
+              activityId,
+              babyId: baby.id,
+              userId: user.id,
+            })
+          } catch {
+            // audit log failure should not break the main flow
+          }
+        } catch (err) {
+          errors.push({
+            originalTexts,
+            error: err instanceof Error ? err.message : '更新失败',
+          })
+        }
+        continue
+      }
+
+      // action === 'create'
       try {
         const activity = await payload.create({
           collection: 'activities',
@@ -115,15 +200,16 @@ export async function PUT(request: NextRequest) {
             startTime: item.startTime,
             endTime: item.endTime || null,
             babyId: baby.id,
-            milkAmount: item.milkAmount || null,
-            milkSource: item.milkSource || null,
+            milkAmount: item.milkAmount ?? null,
+            milkSource: item.milkSource ?? null,
             hasPoop: item.hasPoop ?? null,
             hasPee: item.hasPee ?? null,
-            poopColor: item.poopColor || null,
-            peeAmount: item.peeAmount || null,
-            spitUpType: item.spitUpType || null,
-            count: item.count || null,
-            notes: item.notes || null,
+            poopColor: item.poopColor ?? null,
+            peeAmount: item.peeAmount ?? null,
+            spitUpType: item.spitUpType ?? null,
+            supplementType: item.supplementType ?? null,
+            count: item.count ?? null,
+            notes: item.notes ?? null,
           },
           depth: 0,
           overrideAccess: true,
@@ -132,36 +218,40 @@ export async function PUT(request: NextRequest) {
         created.push({
           id: String(activity.id),
           type: item.type,
-          originalText: item.originalText || '',
+          originalTexts,
         })
 
-        await createAuditLog(payload, {
-          action: 'CREATE',
-          resourceId: String(activity.id),
-          inputMethod: 'VOICE',
-          inputText: item.originalText || '',
-          description: `批量导入: "${item.originalText}" - 创建${item.type}`,
-          success: true,
-          beforeData: null,
-          afterData: activity,
-          activityId: String(activity.id),
-          babyId: baby.id,
-          userId: user.id,
-        })
+        try {
+          await createAuditLog(payload, {
+            action: 'CREATE',
+            resourceId: String(activity.id),
+            inputMethod: 'VOICE',
+            inputText: originalTexts.join(' | '),
+            description: `批量导入: 创建${item.type}`,
+            success: true,
+            beforeData: null,
+            afterData: activity,
+            activityId: String(activity.id),
+            babyId: baby.id,
+            userId: user.id,
+          })
+        } catch {
+          // audit log failure should not break the main flow
+        }
       } catch (err) {
         errors.push({
-          originalText: item.originalText || '',
+          originalTexts,
           error: err instanceof Error ? err.message : '创建失败',
         })
       }
     }
 
-    return NextResponse.json({ created, errors })
+    return NextResponse.json({ created, updated, skipped, errors })
   } catch (error) {
     const authError = authFailureResponse(error)
     if (authError) return authError
 
-    console.error('Batch create failed:', error)
+    console.error('Batch create/update failed:', error)
     return NextResponse.json(
       { error: '批量创建失败', details: error instanceof Error ? error.message : 'Unknown' },
       { status: 500 },

--- a/apps/bubu-log/src/lib/batch-parse/process.ts
+++ b/apps/bubu-log/src/lib/batch-parse/process.ts
@@ -1,0 +1,202 @@
+import type { ActivityType, MilkSource, PoopColor, PeeAmount, SpitUpType, SupplementType } from '@/types/activity'
+
+// Deepseek API configuration
+const DEEPSEEK_API_URL = 'https://api.deepseek.com/chat/completions'
+const DEEPSEEK_TIMEOUT_MS = Number(process.env.DEEPSEEK_BATCH_TIMEOUT_MS || 30000)
+
+/** A single message entry from the user (WeChat paste). */
+export interface BatchEntry {
+  text: string
+  localTime: string
+}
+
+/** One parsed activity returned by the AI. */
+export interface BatchParsedItem {
+  action: 'create' | 'update' | 'skip'
+  type: ActivityType
+  startTime: string // ISO 8601
+  endTime: string | null
+  milkAmount: number | null
+  milkSource: MilkSource | null
+  duration: number | null // minutes
+  hasPoop: boolean | null
+  hasPee: boolean | null
+  poopColor: PoopColor | null
+  peeAmount: PeeAmount | null
+  spitUpType: SpitUpType | null
+  supplementType: SupplementType | null
+  count: number | null
+  notes: string | null
+  skipReason: string | null
+  originalTexts: string[]
+}
+
+/** Result from the batch-parse AI call. */
+export interface BatchParseResult {
+  items: BatchParsedItem[]
+}
+
+/** Error shape from AI. */
+export interface BatchParseError {
+  error: string
+}
+
+const SYSTEM_PROMPT = `你是一个宝宝活动记录助手。用户会粘贴一批微信聊天消息（带时间戳），你需要整体分析所有消息，识别活动、配对开始/结束事件、处理取消，返回一组结构化数据。
+
+## 活动类型 (type)
+- SLEEP: 睡觉/入睡/睡着/醒了/睡眠
+- DIAPER: 换尿布/尿布/大便/小便/拉屎/拉粑粑/便便
+- BREASTFEED: 亲喂/母乳直接喂（非奶瓶）
+  【纠错】清胃/青喂/亲为/亲味/清味/轻味 → 亲喂
+- BOTTLE: 瓶喂/喝奶/奶瓶/喝了XX毫升
+  【奶源 milkSource】BREAST_MILK(母乳,默认) / FORMULA(奶粉/配方奶)
+- PUMP: 吸奶/泵奶/挤奶（妈妈吸奶，记录时长和奶量）
+- SPIT_UP: 吐奶/吐了/喷奶 (spitUpType: PROJECTILE默认 / NORMAL普通)
+- SUPPLEMENT: 补剂/AD/D3 (supplementType: AD / D3)
+- HEAD_LIFT: 抬头/趴着/俯卧
+- PASSIVE_EXERCISE: 被动操/体操
+- ROLL_OVER: 翻身（计数，默认3次）
+- PULL_TO_SIT: 拉坐（计数，默认3次）
+- GAS_EXERCISE: 排气操/排气/蹬腿
+- BATH: 洗澡/沐浴
+- OUTDOOR: 户外/晒太阳/出门/遛弯/户外运动
+- EARLY_EDUCATION: 早教/读书/玩耍
+
+## 便便属性
+- poopColor: YELLOW/GREEN/BROWN/BLACK/WHITE/RED
+- peeAmount: SMALL/MEDIUM/LARGE
+- hasPoop / hasPee: boolean
+
+## 配对规则（非常重要）
+1. "宝宝睡觉了" + 后面的"宝宝醒了" → 合并为一条 SLEEP（action: create, startTime=睡觉时间, endTime=醒了时间）
+2. "开始喝奶/喂奶/亲喂" + "喝了XXml结束/喝完了" → 合并为一条 BOTTLE/BREASTFEED
+3. "开始XXX" + 后面的"取消" → 两条消息都忽略（action: skip, skipReason 说明原因）
+4. 单独的"醒了"（前面没有配对的"睡觉了"）→ action: update（需要匹配系统中未关闭的睡眠记录）
+5. 如果两条消息内容相似且时间接近（如"吸奶10分钟"和"吸奶10分钟160毫升"），后一条是更正/补充，只保留后一条（前一条 skip）
+6. "取消"/"没吃"/"算了" 等取消意图的消息，应该回溯取消最近的相关活动
+
+## 时间解析规则
+- 每条消息都有发送时间（格式 "YYYY-MM-DD HH:mm"）
+- 默认使用消息发送时间作为活动时间
+- 但如果消息内容中提到了具体时间（如"11:00睡觉了"），要用消息中说的时间，而不是发送时间
+- 所有时间用北京时间（UTC+8），输出为 ISO 8601 格式（带 +08:00）
+- 瞬时事件（DIAPER/SUPPLEMENT/SPIT_UP/ROLL_OVER/PULL_TO_SIT）：startTime = endTime
+
+## duration 字段
+- 如果消息中提到了时长（如"吸奶10分钟"），设置 duration 为分钟数
+- 如果有 startTime 和 endTime，duration 可以从中计算
+- 否则为 null
+
+## 返回格式
+返回一个 JSON 数组，每条包含：
+{
+  "action": "create" | "update" | "skip",
+  "type": "活动类型",
+  "startTime": "ISO 8601",
+  "endTime": "ISO 8601 或 null",
+  "milkAmount": 数字或null,
+  "milkSource": "BREAST_MILK"/"FORMULA"/null,
+  "duration": 分钟数或null,
+  "hasPoop": boolean或null,
+  "hasPee": boolean或null,
+  "poopColor": "颜色"或null,
+  "peeAmount": "量"或null,
+  "spitUpType": "PROJECTILE"/"NORMAL"/null,
+  "supplementType": "AD"/"D3"/null,
+  "count": 数字或null,
+  "notes": "备注"或null,
+  "skipReason": "跳过原因"或null (仅 action=skip 时),
+  "originalTexts": ["原始消息1", "原始消息2"]
+}
+
+## 重要
+- 只返回 JSON 数组，不要其他内容
+- originalTexts 包含这条结果对应的所有原始消息文本
+- 每条原始消息最终只能出现在一个结果的 originalTexts 中
+- 不要遗漏任何消息，每条消息都要有归属`
+
+interface DeepseekMessage {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+interface DeepseekResponse {
+  choices: Array<{
+    message: {
+      content: string
+    }
+  }>
+}
+
+/**
+ * Send all entries to Deepseek in a single request for holistic parsing.
+ */
+export async function batchParseWithAI(entries: BatchEntry[]): Promise<BatchParsedItem[]> {
+  const apiKey = process.env.DEEPSEEK_API_KEY
+  if (!apiKey) {
+    throw new Error('DEEPSEEK_API_KEY environment variable is not set')
+  }
+
+  // Format messages for the AI
+  const formattedMessages = entries
+    .map((e) => `[${e.localTime}] ${e.text}`)
+    .join('\n')
+
+  const messages: DeepseekMessage[] = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    {
+      role: 'user',
+      content: `请分析以下微信聊天记录，识别所有宝宝活动并返回结构化数据：\n\n${formattedMessages}`,
+    },
+  ]
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), DEEPSEEK_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(DEEPSEEK_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'deepseek-chat',
+        messages,
+        temperature: 0.1,
+        max_tokens: 4000,
+      }),
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error(`Deepseek batch parse timed out after ${DEEPSEEK_TIMEOUT_MS}ms`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`Deepseek API error: ${response.status} - ${errorText}`)
+  }
+
+  const data: DeepseekResponse = await response.json()
+  const content = data.choices[0]?.message?.content
+
+  if (!content) {
+    throw new Error('Empty response from Deepseek')
+  }
+
+  // Parse JSON response, stripping markdown fences if present
+  const jsonStr = content.replace(/```json\n?|\n?```/g, '').trim()
+  const parsed: unknown = JSON.parse(jsonStr)
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('AI response is not an array')
+  }
+
+  return parsed as BatchParsedItem[]
+}

--- a/apps/bubu-log/src/lib/batch-parse/process.ts
+++ b/apps/bubu-log/src/lib/batch-parse/process.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import type { ActivityType, MilkSource, PoopColor, PeeAmount, SpitUpType, SupplementType } from '@/types/activity'
 
 // Deepseek API configuration
@@ -109,6 +110,12 @@ const SYSTEM_PROMPT = `你是一个宝宝活动记录助手。用户会粘贴一
   "originalTexts": ["原始消息1", "原始消息2"]
 }
 
+## 未配对活动处理
+- 需要开始和结束配对的活动类型：SLEEP、BREASTFEED、BOTTLE、PUMP、HEAD_LIFT、PASSIVE_EXERCISE、GAS_EXERCISE、OUTDOOR、EARLY_EDUCATION
+- 如果只有结束没有开始（如"只有睡醒没有睡着"），且不是 update 场景（即没有系统中可更新的记录），则 action 设为 skip，skipReason 说明原因（如"只有睡醒记录，缺少对应的入睡记录"）
+- 如果只有开始没有结束（如"只有开始吃奶没有结束吃奶"），对于 BREASTFEED 必须有时长或结束时间才能创建，否则 skip；SLEEP 可以只有开始（表示正在睡觉）
+- 单独的"醒了"仍然可以作为 update（更新未关闭的睡眠记录的 endTime）
+
 ## 重要
 - 只返回 JSON 数组，不要其他内容
 - originalTexts 包含这条结果对应的所有原始消息文本
@@ -128,10 +135,49 @@ interface DeepseekResponse {
   }>
 }
 
+// Zod schema for validating individual AI response items
+const batchParsedItemSchema = z.object({
+  action: z.enum(['create', 'update', 'skip']),
+  type: z.string(),
+  startTime: z.string(),
+  endTime: z.string().nullable().optional().default(null),
+  milkAmount: z.number().nullable().optional().default(null),
+  milkSource: z.string().nullable().optional().default(null),
+  duration: z.number().nullable().optional().default(null),
+  hasPoop: z.boolean().nullable().optional().default(null),
+  hasPee: z.boolean().nullable().optional().default(null),
+  poopColor: z.string().nullable().optional().default(null),
+  peeAmount: z.string().nullable().optional().default(null),
+  spitUpType: z.string().nullable().optional().default(null),
+  supplementType: z.string().nullable().optional().default(null),
+  count: z.number().nullable().optional().default(null),
+  notes: z.string().nullable().optional().default(null),
+  skipReason: z.string().nullable().optional().default(null),
+  originalTexts: z.array(z.string()),
+})
+
+const batchParsedResponseSchema = z.array(batchParsedItemSchema)
+
 /**
  * Send all entries to Deepseek in a single request for holistic parsing.
  */
 export async function batchParseWithAI(entries: BatchEntry[]): Promise<BatchParsedItem[]> {
+  // Input validation
+  if (!entries || entries.length === 0) {
+    throw new Error('entries must be a non-empty array')
+  }
+  if (entries.length > 50) {
+    throw new Error('entries must not exceed 50 items')
+  }
+  for (const entry of entries) {
+    if (!entry.text || typeof entry.text !== 'string' || entry.text.trim().length === 0) {
+      throw new Error('Each entry must have a non-empty text field')
+    }
+    if (!entry.localTime || typeof entry.localTime !== 'string') {
+      throw new Error('Each entry must have a localTime field')
+    }
+  }
+
   const apiKey = process.env.DEEPSEEK_API_KEY
   if (!apiKey) {
     throw new Error('DEEPSEEK_API_KEY environment variable is not set')
@@ -198,5 +244,11 @@ export async function batchParseWithAI(entries: BatchEntry[]): Promise<BatchPars
     throw new Error('AI response is not an array')
   }
 
-  return parsed as BatchParsedItem[]
+  const validated = batchParsedResponseSchema.safeParse(parsed)
+  if (!validated.success) {
+    console.error('AI response validation failed:', validated.error.format())
+    throw new Error(`AI response validation failed: ${validated.error.issues.map((i) => i.message).join(', ')}`)
+  }
+
+  return validated.data as BatchParsedItem[]
 }

--- a/apps/bubu-log/tests/batch-import.spec.ts
+++ b/apps/bubu-log/tests/batch-import.spec.ts
@@ -1,55 +1,74 @@
 import { test, expect, login, TEST_BABY_ID } from './fixtures'
 
 const MOCK_PARSE_RESPONSE = {
-  results: [
+  items: [
     {
-      originalText: '瓶喂母乳80毫升',
-      parsed: {
-        type: 'BOTTLE',
-        startTimeISO: '2026-03-27T10:00:00.000Z',
-        endTimeISO: '2026-03-27T10:15:00.000Z',
-        milkAmount: 80,
-        milkSource: 'BREAST_MILK',
-        hasPoop: null,
-        hasPee: null,
-        poopColor: null,
-        peeAmount: null,
-        spitUpType: null,
-        count: null,
-        notes: null,
-        confidence: 0.95,
-      },
+      action: 'create',
+      type: 'BOTTLE',
+      startTime: '2026-03-27T10:00:00+08:00',
+      endTime: '2026-03-27T10:15:00+08:00',
+      milkAmount: 80,
+      milkSource: 'BREAST_MILK',
+      duration: 15,
+      hasPoop: null,
+      hasPee: null,
+      poopColor: null,
+      peeAmount: null,
+      spitUpType: null,
+      supplementType: null,
+      count: null,
+      notes: null,
+      skipReason: null,
+      originalTexts: ['瓶喂母乳80毫升'],
     },
     {
-      originalText: '换尿布有大便黄色',
-      parsed: {
-        type: 'DIAPER',
-        startTimeISO: '2026-03-27T10:30:00.000Z',
-        endTimeISO: '2026-03-27T10:30:00.000Z',
-        milkAmount: null,
-        milkSource: null,
-        hasPoop: true,
-        hasPee: false,
-        poopColor: 'YELLOW',
-        peeAmount: null,
-        spitUpType: null,
-        count: null,
-        notes: null,
-        confidence: 0.9,
-      },
+      action: 'create',
+      type: 'DIAPER',
+      startTime: '2026-03-27T10:30:00+08:00',
+      endTime: '2026-03-27T10:30:00+08:00',
+      milkAmount: null,
+      milkSource: null,
+      duration: null,
+      hasPoop: true,
+      hasPee: false,
+      poopColor: 'YELLOW',
+      peeAmount: null,
+      spitUpType: null,
+      supplementType: null,
+      count: null,
+      notes: null,
+      skipReason: null,
+      originalTexts: ['换尿布有大便黄色'],
     },
     {
-      originalText: '这是一段无法解析的乱码',
-      error: '无法识别活动类型',
+      action: 'skip',
+      type: 'SLEEP',
+      startTime: '2026-03-27T10:30:00+08:00',
+      endTime: null,
+      milkAmount: null,
+      milkSource: null,
+      duration: null,
+      hasPoop: null,
+      hasPee: null,
+      poopColor: null,
+      peeAmount: null,
+      spitUpType: null,
+      supplementType: null,
+      count: null,
+      notes: null,
+      skipReason: '无法识别活动类型',
+      originalTexts: ['这是一段无法解析的乱码'],
     },
   ],
 }
 
-const MOCK_CREATE_RESPONSE = {
+const MOCK_CONFIRM_RESPONSE = {
   created: [
-    { id: 'new-1', type: 'BOTTLE', originalText: '瓶喂母乳80毫升' },
-    { id: 'new-2', type: 'DIAPER', originalText: '换尿布有大便黄色' },
+    { id: 'new-1', type: 'BOTTLE', originalTexts: ['瓶喂母乳80毫升'] },
+    { id: 'new-2', type: 'DIAPER', originalTexts: ['换尿布有大便黄色'] },
   ],
+  updated: [],
+  skipped: [],
   errors: [],
 }
 
@@ -89,7 +108,7 @@ test.describe('Batch Import', () => {
   test('full flow: input -> parse -> review -> confirm', async ({ page }) => {
     await page.goto(`/b/${TEST_BABY_ID}/batch-import`)
 
-    // Mock batch-parse POST (解析)
+    // Mock batch-parse POST and PUT
     await page.route('**/api/app/batch-parse**', async (route) => {
       const method = route.request().method()
       if (method === 'POST') {
@@ -102,73 +121,68 @@ test.describe('Batch Import', () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(MOCK_CREATE_RESPONSE),
+          body: JSON.stringify(MOCK_CONFIRM_RESPONSE),
         })
       } else {
         await route.continue()
       }
     })
 
-    // Step 1: 输入文本
+    // Step 1: Input text
     const textarea = page.getByTestId('batch-input-textarea')
     await textarea.fill('瓶喂母乳80毫升\n换尿布有大便黄色\n这是一段无法解析的乱码')
 
-    // 截图：输入步骤
     await page.screenshot({ path: 'test-results/batch-import-step1-input.png', fullPage: true })
 
-    // 点击解析
+    // Click parse
     await page.getByTestId('batch-parse-btn').click()
 
-    // Step 2: 等待进入 review 步骤
+    // Step 2: Wait for review step
     await expect(page.getByTestId('batch-result-item-0')).toBeVisible({ timeout: 5000 })
 
-    // 验证解析结果显示
+    // Verify parsed results
     await expect(page.getByTestId('batch-result-item-0')).toContainText('瓶喂母乳80毫升')
     await expect(page.getByTestId('batch-result-item-1')).toContainText('换尿布有大便黄色')
-    // 第三条应该显示错误
+    // Third item should show skip reason
     await expect(page.getByTestId('batch-result-item-2')).toContainText('无法识别活动类型')
 
-    // 验证 checkbox 状态：前两条默认选中，第三条失败无 checkbox
+    // Verify checkbox state: first two checked, third is skip (no checkbox)
     await expect(page.getByTestId('batch-check-0')).toBeVisible()
     await expect(page.getByTestId('batch-check-1')).toBeVisible()
 
-    // 确认按钮显示选中数量
+    // Confirm button shows checked count
     const confirmBtn = page.getByTestId('batch-confirm-btn')
     await expect(confirmBtn).toContainText('确认导入 (2)')
 
-    // 截图：审核步骤
     await page.screenshot({ path: 'test-results/batch-import-step2-review.png', fullPage: true })
 
-    // 取消勾选第一条
+    // Uncheck first item
     await page.getByTestId('batch-check-0').click()
     await expect(confirmBtn).toContainText('确认导入 (1)')
 
-    // 截图：取消勾选后
     await page.screenshot({ path: 'test-results/batch-import-step2-uncheck.png', fullPage: true })
 
-    // 重新勾选
+    // Re-check
     await page.getByTestId('batch-check-0').click()
     await expect(confirmBtn).toContainText('确认导入 (2)')
 
-    // 点击确认导入
+    // Click confirm
     await confirmBtn.click()
 
-    // Step 3: 等待完成步骤
+    // Step 3: Wait for done
     await expect(page.getByTestId('batch-done-card')).toBeVisible({ timeout: 5000 })
-    await expect(page.getByTestId('batch-done-card')).toContainText('成功导入 2 条记录')
+    await expect(page.getByTestId('batch-done-card')).toContainText('新建 2 条')
 
-    // 截图：完成步骤
     await page.screenshot({ path: 'test-results/batch-import-step3-done.png', fullPage: true })
 
-    // 点击继续导入，回到输入步骤
+    // Click continue, back to input
     await page.getByTestId('batch-reset-btn').click()
     await expect(page.getByTestId('batch-input-textarea')).toBeVisible()
   })
 
-  test('toggle all button should select/deselect all parsed items', async ({ page }) => {
+  test('toggle all button should select/deselect all non-skip items', async ({ page }) => {
     await page.goto(`/b/${TEST_BABY_ID}/batch-import`)
 
-    // Mock
     await page.route('**/api/app/batch-parse**', async (route) => {
       if (route.request().method() === 'POST') {
         await route.fulfill({
@@ -185,11 +199,11 @@ test.describe('Batch Import', () => {
     await page.getByTestId('batch-parse-btn').click()
     await expect(page.getByTestId('batch-result-item-0')).toBeVisible({ timeout: 5000 })
 
-    // 点击取消全选
+    // Click deselect all
     await page.getByTestId('batch-toggle-all').click()
     await expect(page.getByTestId('batch-confirm-btn')).toContainText('确认导入 (0)')
 
-    // 点击全选
+    // Click select all
     await page.getByTestId('batch-toggle-all').click()
     await expect(page.getByTestId('batch-confirm-btn')).toContainText('确认导入 (2)')
   })
@@ -197,44 +211,41 @@ test.describe('Batch Import', () => {
   test('should parse timestamp+description format from chat logs', async ({ page }) => {
     await page.goto(`/b/${TEST_BABY_ID}/batch-import`)
 
-    // Mock - verify entries have per-record localTime
     await page.route('**/api/app/batch-parse**', async (route) => {
       if (route.request().method() === 'POST') {
         const body = JSON.parse(route.request().postData() || '{}')
-        // Verify entries format with individual timestamps
         const entries = body.entries as Array<{ text: string; localTime: string }>
         if (entries && entries.length === 2) {
-          // Check first entry has timestamp from paste
           if (entries[0].localTime.includes('08:30') && entries[1].localTime.includes('09:00')) {
             await route.fulfill({
               status: 200,
               contentType: 'application/json',
               body: JSON.stringify({
-                results: [
+                items: [
                   {
-                    originalText: '宝宝喝了80毫升奶',
-                    parsed: {
-                      type: 'BOTTLE',
-                      startTimeISO: '2026-03-27T00:30:00.000Z',
-                      endTimeISO: '2026-03-27T00:45:00.000Z',
-                      milkAmount: 80,
-                      milkSource: 'BREAST_MILK',
-                      hasPoop: null, hasPee: null, poopColor: null, peeAmount: null,
-                      spitUpType: null, count: null, notes: null,
-                      confidence: 0.95,
-                    },
+                    action: 'create',
+                    type: 'BOTTLE',
+                    startTime: '2026-03-27T08:30:00+08:00',
+                    endTime: '2026-03-27T08:45:00+08:00',
+                    milkAmount: 80,
+                    milkSource: 'BREAST_MILK',
+                    duration: 15,
+                    hasPoop: null, hasPee: null, poopColor: null, peeAmount: null,
+                    spitUpType: null, supplementType: null, count: null, notes: null,
+                    skipReason: null,
+                    originalTexts: ['宝宝喝了80毫升奶'],
                   },
                   {
-                    originalText: '宝宝睡觉了',
-                    parsed: {
-                      type: 'SLEEP',
-                      startTimeISO: '2026-03-27T01:00:00.000Z',
-                      endTimeISO: null,
-                      milkAmount: null, milkSource: null,
-                      hasPoop: null, hasPee: null, poopColor: null, peeAmount: null,
-                      spitUpType: null, count: null, notes: null,
-                      confidence: 0.9,
-                    },
+                    action: 'create',
+                    type: 'SLEEP',
+                    startTime: '2026-03-27T09:00:00+08:00',
+                    endTime: null,
+                    milkAmount: null, milkSource: null,
+                    duration: null,
+                    hasPoop: null, hasPee: null, poopColor: null, peeAmount: null,
+                    spitUpType: null, supplementType: null, count: null, notes: null,
+                    skipReason: null,
+                    originalTexts: ['宝宝睡觉了'],
                   },
                 ],
               }),
@@ -252,7 +263,6 @@ test.describe('Batch Import', () => {
       }
     })
 
-    // 粘贴带时间戳的聊天记录格式
     const chatLog = [
       '【宝宝每日数据记录】',
       '2026/3/27 08:30',
@@ -263,18 +273,15 @@ test.describe('Batch Import', () => {
 
     await page.getByTestId('batch-input-textarea').fill(chatLog)
 
-    // 截图：带时间戳格式的输入
     await page.screenshot({ path: 'test-results/batch-import-timestamp-input.png', fullPage: true })
 
     await page.getByTestId('batch-parse-btn').click()
 
-    // 验证解析结果
     await expect(page.getByTestId('batch-result-item-0')).toBeVisible({ timeout: 5000 })
     await expect(page.getByTestId('batch-result-item-0')).toContainText('宝宝喝了80毫升奶')
     await expect(page.getByTestId('batch-result-item-1')).toContainText('宝宝睡觉了')
     await expect(page.getByTestId('batch-confirm-btn')).toContainText('确认导入 (2)')
 
-    // 截图：时间戳格式的审核界面
     await page.screenshot({ path: 'test-results/batch-import-timestamp-review.png', fullPage: true })
   })
 
@@ -297,10 +304,9 @@ test.describe('Batch Import', () => {
     await page.getByTestId('batch-parse-btn').click()
     await expect(page.getByTestId('batch-result-item-0')).toBeVisible({ timeout: 5000 })
 
-    // 点击返回修改
+    // Click back
     await page.getByTestId('batch-back-btn').click()
     await expect(page.getByTestId('batch-input-textarea')).toBeVisible()
-    // 原来的文本应该还在
     await expect(page.getByTestId('batch-input-textarea')).toHaveValue('瓶喂母乳80毫升')
   })
 })


### PR DESCRIPTION
## Summary
- Rewrites batch-parse to send all messages to Deepseek in a single request for holistic activity parsing, replacing the previous per-entry approach (PR #106)
- AI now handles start/end event pairing, cancellation detection, duplicate deduplication, and context-aware time parsing in one pass
- Adds dedicated `batch-parse/process.ts` module with a specialized prompt (separate from voice-input)
- Supports `create`, `update`, and `skip` actions -- `update` finds unclosed SLEEP records within 12h
- Baby ownership validation on update, audit log failures isolated with try/catch

**This replaces the incorrect implementation in PR #106.**

## Changes
- **New**: `apps/bubu-log/src/lib/batch-parse/process.ts` -- dedicated AI prompt and Deepseek call
- **Rewritten**: `apps/bubu-log/src/app/api/app/batch-parse/route.ts` -- POST returns `{ items }` with action/type/times/originalTexts; PUT handles create/update/skip with validation
- **Updated**: Frontend `batch-import/page.tsx` -- adapts to new API shape, shows action badges (create/update/skip), improved done summary
- **Updated**: `openapi.yaml` -- added `/batch-parse` POST/PUT definitions and `BatchParsedItem`/`BatchConfirmItem` schemas
- **Updated**: `tests/batch-import.spec.ts` -- mock data matches new response format

## Test plan
- [ ] Paste WeChat chat logs with timestamps and verify AI parses all activities correctly
- [ ] Verify paired events (sleep+wake, start feed+end feed) are merged into single items
- [ ] Verify cancel messages cause related items to be skipped
- [ ] Verify "update" action for standalone "wake up" finds unclosed sleep
- [ ] Run e2e tests: `pnpm --filter bubu-log test:e2e -- batch-import`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch parsing and review: submit multiple entries (up to 50) for AI parsing with timezone-aware times; parsed items show action badges (create/update/skip) and original text groups.
  * Batch confirm: confirm parsed items in one operation with create/update/skip actions; updates can attach to existing activities.

* **UI Improvements**
  * Skip styling and skip-reason display; skipped items are not selectable and toggle-all affects only actionable items.
  * Summary and toasts now report created/updated/skipped/errors counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->